### PR TITLE
Fix documentation builds on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,12 +11,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import os
+import sys
+
+import sphinx_rtd_theme
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
-
-import sphinx_rtd_theme
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/transforms.rst
+++ b/docs/transforms.rst
@@ -27,7 +27,7 @@ NoTransform
 ^^^^^^^^^^^^^
 .. autoclass:: NoTransform
 
-Lamda
+Lambda
 ^^^^^^^^^
 .. autoclass:: Lambda
 

--- a/torchsig/transforms/deep_learning_techniques/dlt.py
+++ b/torchsig/transforms/deep_learning_techniques/dlt.py
@@ -23,7 +23,7 @@ class DatasetBasebandMixUp(SignalTransform):
     than zero.
     
     This transform is loosely based on 
-    `"mixup: Beyond Emperical Risk Minimization" <https://arxiv.org/pdf/1710.09412.pdf>`_.
+    `"mixup: Beyond Empirical Risk Minimization" <https://arxiv.org/pdf/1710.09412.pdf>`_.
 
     
     Args:


### PR DESCRIPTION
Documentation builds on https://torchsig.readthedocs.io/en/latest/index.html were missing API docs for all classes
in the `torchsig` module.

See build log at: https://readthedocs.org/api/v2/build/18186342.txt

The root cause is that the RTD environment doesn't actually install the torchsig module, just its dependencies, so we have
to configure sphinx (in `doc/conf.py`) to point to the directory from which `import torchsig` will work.