### PR TITLE
Fix several imports and typing annotations

### DIFF
--- a/torchsig/datasets/modulations.py
+++ b/torchsig/datasets/modulations.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Optional, Callable
+from typing import Optional, Callable, List
 from torch.utils.data import ConcatDataset
 
 from torchsig.datasets import DigitalModulationDataset, OFDMDataset
@@ -120,7 +120,7 @@ class ModulationsDataset(ConcatDataset):
 
     def __init__(
         self,
-        classes: list = None,    
+        classes: Optional[List[str]] = None,
         use_class_idx: bool = False,
         level: int = 0,
         num_iq_samples: int = 2048,

--- a/torchsig/datasets/radioml.py
+++ b/torchsig/datasets/radioml.py
@@ -37,7 +37,7 @@ class RadioML2016(SignalDataset):
     def __init__(
         self,
         root: str,
-        classes: list = None,
+        classes: Optional[List[str]] = None,
         use_class_idx: bool = False,
         include_snr: bool = False,
         snr_threshold: int = -2,

--- a/torchsig/transforms/functional.py
+++ b/torchsig/transforms/functional.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union, Tuple, List
+from typing import Callable, List, Protocol, Sequence, Tuple, Union
 from functools import partial
 import numpy as np
 
@@ -7,7 +7,25 @@ IntParameter = Union[Callable[[int], int], int, Tuple[int, int], List]
 NumericParameter = Union[FloatParameter, IntParameter]
 
 
-def uniform_discrete_distribution(choices: List, random_generator: np.random.RandomState = np.random.RandomState()):
+class RandomStatePartial(Protocol):
+    """Type definition for the partially applied random distribution function
+    returned by the functions in this module.
+
+    These partials can be either called with zero arguments, in which case a
+    single value is returned, or by passing in a size parameter, in which case
+    a np.ndarray of the specified shape is returned.
+
+    See: https://peps.python.org/pep-0544/
+    See: https://mypy.readthedocs.io/en/stable/protocols.html#callback-protocols
+    """
+    def __call__(self, size: Union[int, Sequence[int]] = ...) -> np.typing.ArrayLike:
+        ...
+
+
+def uniform_discrete_distribution(
+        choices: List,
+        random_generator: np.random.RandomState = np.random.RandomState()
+) -> RandomStatePartial:
     return partial(random_generator.choice, choices)
 
 
@@ -15,11 +33,14 @@ def uniform_continuous_distribution(
         lower: Union[int, float],
         upper: Union[int, float],
         random_generator: np.random.RandomState = np.random.RandomState()
-):
+) -> RandomStatePartial:
     return partial(random_generator.uniform, lower, upper)
 
 
-def to_distribution(param, random_generator: np.random.RandomState = np.random.RandomState()):
+def to_distribution(
+        param: NumericParameter,
+        random_generator: np.random.RandomState = np.random.RandomState()
+) -> RandomStatePartial:
     if isinstance(param, Callable):
         return param
 

--- a/torchsig/transforms/system_impairment/si.py
+++ b/torchsig/transforms/system_impairment/si.py
@@ -1,7 +1,7 @@
 import numpy as np
 from copy import deepcopy
 from scipy import signal as sp
-from typing import Optional, Any, Union, List
+from typing import Optional, Any, Union, List, Callable
 
 from torchsig.utils.types import SignalData, SignalDescription
 from torchsig.transforms.transforms import SignalTransform
@@ -945,7 +945,7 @@ class RandomDropSamples(SignalTransform):
         self,
         drop_rate: NumericParameter = uniform_continuous_distribution(0.01,0.05),
         size: NumericParameter = uniform_discrete_distribution(np.arange(1,10)),
-        fill: Union[List, str] = uniform_discrete_distribution(["ffill", "bfill", "mean", "zero"]),
+        fill: Union[Callable, List, str] = uniform_discrete_distribution(["ffill", "bfill", "mean", "zero"]),
     ):
         super(RandomDropSamples, self).__init__()
         self.drop_rate = to_distribution(drop_rate, self.random_generator)

--- a/torchsig/transforms/wireless_channel/wce.py
+++ b/torchsig/transforms/wireless_channel/wce.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import numpy as np
 from typing import Optional, Tuple, List, Union, Any
 

--- a/torchsig/utils/dataset.py
+++ b/torchsig/utils/dataset.py
@@ -20,7 +20,7 @@ class SignalDataset(torch.utils.data.Dataset):
         self,
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
-        seed: int = None
+        seed: Optional[int] = None
     ):
         super(SignalDataset, self).__init__()
         self.random_generator = np.random.RandomState(seed)

--- a/torchsig/utils/types.py
+++ b/torchsig/utils/types.py
@@ -91,7 +91,7 @@ class SignalData:
     """
     def __init__(
         self,
-        data: bytes,
+        data: Optional[bytes],
         item_type: np.dtype,
         data_type: np.dtype,
         signal_description: Optional[Union[List[SignalDescription], SignalDescription]] = None

--- a/torchsig/utils/visualize.py
+++ b/torchsig/utils/visualize.py
@@ -4,7 +4,7 @@ from scipy import ndimage
 from scipy import signal as sp
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
-from torch.utils.data import dataloader
+from torch.utils.data import DataLoader
 from typing import Optional, Callable, Iterable, Union, Tuple, List
 
 
@@ -24,7 +24,7 @@ class Visualizer:
     """
     def __init__(
         self,
-        data_loader: dataloader,
+        data_loader: DataLoader,
         visualize_transform: Optional[Callable] = None,
         visualize_target_transform: Optional[Callable] = None
     ):
@@ -358,7 +358,7 @@ def onehot_label_format(tensor: np.ndarray) -> List[str]:
     return label
 
 
-def multihot_label_format(tensor: np.ndarray, class_list: List[str]) -> List[str]:
+def multihot_label_format(tensor: np.ndarray, class_list: List[str]) -> List[List[str]]:
     """Target Transform: Format multihot labels for titles in visualizer
     
     """


### PR DESCRIPTION
This is a set of minor fixes all relating to typing annotations not matching the actual types in use by the library.

The one new piece of code here is to add return type annotations to the functions in `torchsig.transforms.functional`, allowing transforms which use them to be checked. This is slightly more complex than other annotations, since the return types are partially applied functions, and these partials themselves have optional arguments with default values -- so they can't be directly represented as a `Callable[[Arg1, Arg2, ...], Return]`-style annotation.