### PR TITLE
Ensure AGC algorithm always has an initial level value

### DIFF
--- a/torchsig/transforms/system_impairment/functional.py
+++ b/torchsig/transforms/system_impairment/functional.py
@@ -613,9 +613,12 @@ def agc(
     """
     output = np.zeros_like(tensor)
     gain_db = initial_gain_db
+    level_db = 0.0
     for sample_idx, sample in enumerate(tensor):
         if np.abs(sample) == 0:
             level_db = -200
+        elif sample_idx == 0:  # first sample, no smoothing
+            level_db = np.log(np.abs(sample))
         else:
             level_db = level_db*alpha_smooth + np.log(np.abs(sample))*(1 - alpha_smooth)
         output_db = level_db + gain_db


### PR DESCRIPTION
If `np.abs(sample) != 0` for the first sample, the else branch is hit on the very first loop iteration. This results in a `NameError` since the `level_db` variable is not yet defined.

This fix also sets an initial value for `level_db` because static checkers can't generally figure out that the else branch can no longer be hit on the first loop iteration.