### PR TITLE
Fix type checking for subclasses of types

### DIFF
--- a/torchsig/models/efficientnet.py
+++ b/torchsig/models/efficientnet.py
@@ -78,7 +78,7 @@ class GBN(torch.nn.Module):
     
 def replace_bn(parent):
     for n, m in parent.named_children():
-        if type(m) is nn.BatchNorm2d:
+        if isinstance(m, nn.BatchNorm2d):
             setattr(
                 parent,
                 n,
@@ -90,7 +90,7 @@ def replace_bn(parent):
 
 def replace_se(parent):
     for n, m in parent.named_children():
-        if type(m) is timm.models.efficientnet_blocks.SqueezeExcite:
+        if isinstance(m, timm.models.efficientnet_blocks.SqueezeExcite):
             setattr(
                 parent,
                 n,


### PR DESCRIPTION
When restoring the pre-trained EfficientNet B4 weights in the example notebook, the code fails to replace BatchNorm2D with GhostNorm because the timm repo uses a subclass of nn.BatchNorm2d which fails the type check in the current code: 

https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/layers/norm_act.py#L26

"isinstance" is a safer way to do the type checking. 

