### PR TITLE
Add sympy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ icecream
 timm==0.5.4
 segmentation_models_pytorch
 pytorch_lightning
+sympy


### PR DESCRIPTION
Following the TorchSig install instructions and importing `torchsig` yields the following error:

```
>>> import torchsig
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adamt/projects/torchsig/torchsig/__init__.py", line 4, in <module>
    from torchsig import models
  File "/home/adamt/projects/torchsig/torchsig/models/__init__.py", line 2, in <module>
    from . import spectrogram_models
  File "/home/adamt/projects/torchsig/torchsig/models/spectrogram_models/__init__.py", line 3, in <module>
    from .pspnet import *
  File "/home/adamt/projects/torchsig/torchsig/models/spectrogram_models/pspnet/__init__.py", line 1, in <module>
    from .pspnet import *
  File "/home/adamt/projects/torchsig/torchsig/models/spectrogram_models/pspnet/pspnet.py", line 8, in <module>
    from .modules import *
  File "/home/adamt/projects/torchsig/torchsig/models/spectrogram_models/pspnet/modules.py", line 6, in <module>
    from .utils import replace_bn
  File "/home/adamt/projects/torchsig/torchsig/models/spectrogram_models/pspnet/utils.py", line 1, in <module>
    import sympy
ModuleNotFoundError: No module named 'sympy'
```

By adding `sympy` to the pip requirements file, we can successfully import and install torchsig.