### PR TITLE
Start transform tests & minor `RandomTimeShift` optimization

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,72 +1,121 @@
-import numpy as np
-import os
-import shutil
 from unittest import TestCase
-
-import torchsig.transforms.system_impairment.si as SIT
+from torchsig.transforms.system_impairment.si import RandomTimeShift, TimeCrop
+import numpy as np
 
 
 class RandomTimeShiftTests(TestCase):
-    def test_RandomTimeShift_right(self):
+    def test_random_time_shift_right(self):
         rng = np.random.RandomState(0)
-        data = (rng.rand(16,) - 0.5) + 1j * (rng.rand(16,) - 0.5)
+        data = (
+            rng.rand(
+                16,
+            )
+            - 0.5
+        ) + 1j * (
+            rng.rand(
+                16,
+            )
+            - 0.5
+        )
         shift = 5
-        t = SIT.RandomTimeShift(
+        t = RandomTimeShift(
             shift=shift,
         )
         new_data = t(data)
         self.assertTrue(np.allclose(data[:-shift], new_data[shift:]))
         self.assertTrue(np.allclose(new_data[:shift], np.zeros(shift)))
-    
-    def test_RandomTimeShift_left(self):
+
+    def test_random_time_shift_left(self):
         rng = np.random.RandomState(0)
-        data = (rng.rand(16,) - 0.5) + 1j * (rng.rand(16,) - 0.5)
+        data = (
+            rng.rand(
+                16,
+            )
+            - 0.5
+        ) + 1j * (
+            rng.rand(
+                16,
+            )
+            - 0.5
+        )
         shift = -5
-        t = SIT.RandomTimeShift(
+        t = RandomTimeShift(
             shift=shift,
         )
         new_data = t(data)
         self.assertTrue(np.allclose(data[-shift:], new_data[:shift]))
         self.assertTrue(np.allclose(new_data[shift:], np.zeros(np.abs(shift))))
-        
-        
+
+
 class TimeCrop(TestCase):
-    def test_TimeCrop_start(self):
+    def test_time_crop_start(self):
         rng = np.random.RandomState(0)
         num_iq_samples = 16
-        data = (rng.rand(num_iq_samples,) - 0.5) + 1j * (rng.rand(num_iq_samples,) - 0.5)
+        data = (
+            rng.rand(
+                num_iq_samples,
+            )
+            - 0.5
+        ) + 1j * (
+            rng.rand(
+                num_iq_samples,
+            )
+            - 0.5
+        )
         length = 4
-        t = SIT.TimeCrop(
+        t = TimeCrop(
             crop_type="start",
             length=length,
         )
-        new_data = t(data)
+        new_data: np.ndarray = t(data)
         self.assertTrue(np.allclose(data[:length], new_data))
         self.assertTrue(new_data.shape[0] == length)
 
-    def test_TimeCrop_center(self):
+    def test_time_crop_center(self):
         rng = np.random.RandomState(0)
         num_iq_samples = 16
-        data = (rng.rand(num_iq_samples,) - 0.5) + 1j * (rng.rand(num_iq_samples,) - 0.5)
+        data = (
+            rng.rand(
+                num_iq_samples,
+            )
+            - 0.5
+        ) + 1j * (
+            rng.rand(
+                num_iq_samples,
+            )
+            - 0.5
+        )
         length = 4
-        t = SIT.TimeCrop(
+        t = TimeCrop(
             crop_type="center",
             length=length,
         )
-        new_data = t(data)
+        new_data: np.ndarray = t(data)
         extra_samples = num_iq_samples - length
-        self.assertTrue(np.allclose(data[extra_samples // 2:-extra_samples // 2], new_data))
+        self.assertTrue(
+            np.allclose(data[extra_samples // 2 : -extra_samples // 2], new_data)
+        )
         self.assertTrue(new_data.shape[0] == length)
 
-    def test_TimeCrop_end(self):
+    def test_time_crop_end(self):
         rng = np.random.RandomState(0)
         num_iq_samples = 16
-        data = (rng.rand(num_iq_samples,) - 0.5) + 1j * (rng.rand(num_iq_samples,) - 0.5)
+        data = (
+            rng.rand(
+                num_iq_samples,
+            )
+            - 0.5
+        ) + 1j * (
+            rng.rand(
+                num_iq_samples,
+            )
+            - 0.5
+        )
         length = 4
-        t = SIT.TimeCrop(
+        t = TimeCrop(
             crop_type="end",
             length=length,
         )
-        new_data = t(data)
+        new_data: np.ndarray = t(data)
         self.assertTrue(np.allclose(data[-length:], new_data))
         self.assertTrue(new_data.shape[0] == length)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -42,6 +42,7 @@ class TimeCrop(TestCase):
         )
         new_data = t(data)
         self.assertTrue(np.allclose(data[:length], new_data))
+        self.assertTrue(new_data.shape[0] == length)
 
     def test_TimeCrop_center(self):
         rng = np.random.RandomState(0)
@@ -55,7 +56,8 @@ class TimeCrop(TestCase):
         new_data = t(data)
         extra_samples = num_iq_samples - length
         self.assertTrue(np.allclose(data[extra_samples // 2:-extra_samples // 2], new_data))
-        
+        self.assertTrue(new_data.shape[0] == length)
+
     def test_TimeCrop_end(self):
         rng = np.random.RandomState(0)
         num_iq_samples = 16
@@ -67,3 +69,4 @@ class TimeCrop(TestCase):
         )
         new_data = t(data)
         self.assertTrue(np.allclose(data[-length:], new_data))
+        self.assertTrue(new_data.shape[0] == length)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,69 @@
+import numpy as np
+import os
+import shutil
+from unittest import TestCase
+
+import torchsig.transforms.system_impairment.si as SIT
+
+
+class RandomTimeShiftTests(TestCase):
+    def test_RandomTimeShift_right(self):
+        rng = np.random.RandomState(0)
+        data = (rng.rand(16,) - 0.5) + 1j * (rng.rand(16,) - 0.5)
+        shift = 5
+        t = SIT.RandomTimeShift(
+            shift=shift,
+        )
+        new_data = t(data)
+        self.assertTrue(np.allclose(data[:-shift], new_data[shift:]))
+        self.assertTrue(np.allclose(new_data[:shift], np.zeros(shift)))
+    
+    def test_RandomTimeShift_left(self):
+        rng = np.random.RandomState(0)
+        data = (rng.rand(16,) - 0.5) + 1j * (rng.rand(16,) - 0.5)
+        shift = -5
+        t = SIT.RandomTimeShift(
+            shift=shift,
+        )
+        new_data = t(data)
+        self.assertTrue(np.allclose(data[-shift:], new_data[:shift]))
+        self.assertTrue(np.allclose(new_data[shift:], np.zeros(np.abs(shift))))
+        
+        
+class TimeCrop(TestCase):
+    def test_TimeCrop_start(self):
+        rng = np.random.RandomState(0)
+        num_iq_samples = 16
+        data = (rng.rand(num_iq_samples,) - 0.5) + 1j * (rng.rand(num_iq_samples,) - 0.5)
+        length = 4
+        t = SIT.TimeCrop(
+            crop_type="start",
+            length=length,
+        )
+        new_data = t(data)
+        self.assertTrue(np.allclose(data[:length], new_data))
+
+    def test_TimeCrop_center(self):
+        rng = np.random.RandomState(0)
+        num_iq_samples = 16
+        data = (rng.rand(num_iq_samples,) - 0.5) + 1j * (rng.rand(num_iq_samples,) - 0.5)
+        length = 4
+        t = SIT.TimeCrop(
+            crop_type="center",
+            length=length,
+        )
+        new_data = t(data)
+        extra_samples = num_iq_samples - length
+        self.assertTrue(np.allclose(data[extra_samples // 2:-extra_samples // 2], new_data))
+        
+    def test_TimeCrop_end(self):
+        rng = np.random.RandomState(0)
+        num_iq_samples = 16
+        data = (rng.rand(num_iq_samples,) - 0.5) + 1j * (rng.rand(num_iq_samples,) - 0.5)
+        length = 4
+        t = SIT.TimeCrop(
+            crop_type="end",
+            length=length,
+        )
+        new_data = t(data)
+        self.assertTrue(np.allclose(data[-length:], new_data))

--- a/torchsig/transforms/system_impairment/si.py
+++ b/torchsig/transforms/system_impairment/si.py
@@ -67,12 +67,13 @@ class RandomTimeShift(SignalTransform):
             )            
             
             # Apply data transformation
-            new_data.iq_data = functional.fractional_shift(
-                data.iq_data,
-                self.taps,
-                self.interp_rate,
-                -decimal_part  # this needed to be negated to be consistent with the previous implementation
-            )
+            if decimal_part != 0:
+                new_data.iq_data = functional.fractional_shift(
+                    data.iq_data,
+                    self.taps,
+                    self.interp_rate,
+                    -decimal_part  # this needed to be negated to be consistent with the previous implementation
+                )
             new_data.iq_data = functional.time_shift(new_data.iq_data, int(integer_part))
             
             # Update SignalDescription
@@ -91,12 +92,14 @@ class RandomTimeShift(SignalTransform):
             new_data.signal_description = new_signal_description
             
         else:
-            new_data = functional.fractional_shift(
-                data,
-                self.taps,
-                self.interp_rate,
-                -decimal_part  # this needed to be negated to be consistent with the previous implementation
-            )
+            new_data = data.copy()
+            if decimal_part != 0:
+                new_data = functional.fractional_shift(
+                    new_data,
+                    self.taps,
+                    self.interp_rate,
+                    -decimal_part  # this needed to be negated to be consistent with the previous implementation
+                )
             new_data = functional.time_shift(new_data, int(integer_part))
         return new_data
 


### PR DESCRIPTION
Created two transform tests such that examples exist for futures to be built for the other transforms (by any eager member of the growing community :) ).

Also included a slight optimization in the `RandomTimeShift` transform such that we skip over the fractional shift method if the input is an integer. Note that this does actually change the output of the transform in a very minor way because previously integer shifts still got passed through the fractional time shift with a fractional shift value of 0. In any datasets, this is likely to not change any outputs as all of the parameters for `RandomTimeShift` have been uniform floating point distributions, and it is very unlikely they ever fell perfectly on an integer value.

Tests:
```
pytest -v
```

Output:
```
======================================================================== test session starts ========================================================================
platform linux -- Python 3.8.13, pytest-7.3.1, pluggy-1.0.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /workspace/torchsig
plugins: anyio-3.6.1
collected 10 items                                                                                                                                                  

tests/test_datasets_sig53.py::GenerateSig53::test_can_generate_sig53_clean_train PASSED                                                                       
[ 10%]
tests/test_datasets_sig53.py::GenerateSig53::test_can_generate_sig53_clean_val PASSED                                                                         
[ 20%]
tests/test_datasets_sig53.py::GenerateSig53::test_can_generate_sig53_impaired_train PASSED                                                                    
[ 30%]
tests/test_datasets_sig53.py::GenerateSig53::test_can_generate_sig53_impaired_val PASSED                                                                      
[ 40%]
tests/test_transforms.py::RandomTimeShiftTests::test_RandomTimeShift_left PASSED                                                                              
[ 50%]
tests/test_transforms.py::RandomTimeShiftTests::test_RandomTimeShift_right PASSED                                                                             
[ 60%]
tests/test_transforms.py::TimeCrop::test_TimeCrop_center PASSED                                                                                               
[ 70%]
tests/test_transforms.py::TimeCrop::test_TimeCrop_end PASSED                                                                                                  
[ 80%]
tests/test_transforms.py::TimeCrop::test_TimeCrop_start PASSED                                                                                                
[ 90%]
tests/test_writer.py::SeedModulationDataset::test_can_seed_modulation_dataset PASSED                                                                        
[100%]
```