### PR TITLE
QAM/PSK Pulse shaping filter transition bandwidth corrected

### DIFF
--- a/torchsig/datasets/synthetic.py
+++ b/torchsig/datasets/synthetic.py
@@ -366,6 +366,8 @@ class ConstellationDataset(SyntheticDataset):
             (self.iq_samples_per_symbol * len(symbols),), dtype=np.complex64
         )
         zero_padded[:: self.iq_samples_per_symbol] = symbols
+        # excess bandwidth is defined in porportion to signal bandwidth, not sampling rate,
+        # thus needs to be scaled by the samples per symbol
         pulse_shape_filter_length = estimate_filter_length(
             signal_description.excess_bandwidth/self.iq_samples_per_symbol
         )


### PR DESCRIPTION
Filter estimate previously used the excess bandwidth (ex: roll-off factor) for determining the length of the pulse shaping filter for QAM/PSK. But the excess bandwidth is within proportion to the bandwidth, not the sampling rate. For example, excess_bandwidth = 0.35 needs to be scaled by the samples per symbol, such that the transition bandwidth of the pulse shaping filter is excess_bandwidth/samples_per_symbol.