### PR TITLE
OFDM Modulator filter lengths estimated and bandwidth randomized

### DIFF
--- a/torchsig/datasets/synthetic.py
+++ b/torchsig/datasets/synthetic.py
@@ -501,14 +501,16 @@ class OFDMDataset(SyntheticDataset):
         self.index = []
         if "lpf" in sidelobe_suppression_methods:
             # Precompute LPF
-            num_taps = 50
-            cutoff = 0.6
+            cutoff = 0.3
+            transition_bandwidth = (0.5-cutoff)/4
+            num_taps = estimate_filter_length(transition_bandwidth)
             self.taps = sp.firwin(
                 num_taps,
                 cutoff,
-                width=cutoff * 0.02,
+                width=transition_bandwidth,
                 window=sp.get_window("blackman", num_taps),
                 scale=True,
+                fs=1
             )
 
         # Precompute all possible random symbols for speed at sample generation

--- a/torchsig/datasets/synthetic.py
+++ b/torchsig/datasets/synthetic.py
@@ -738,14 +738,16 @@ class OFDMDataset(SyntheticDataset):
         elif sidelobe_suppression_method == "rand_lpf":
             flattened = cyclic_prefixed.T.flatten()
             # Generate randomized LPF
-            cutoff = np.random.uniform(0.95, 0.95)
-            num_taps = estimate_filter_length(cutoff)
+            cutoff = np.random.uniform(0.25, 0.475)
+            transition_bandwidth = (0.5-cutoff)/4
+            num_taps = estimate_filter_length(transition_bandwidth)
             taps = sp.firwin(
                 num_taps,
                 cutoff,
-                width=cutoff * 0.02,
+                width=transition_bandwidth,
                 window=sp.get_window("blackman", num_taps),
                 scale=True,
+                fs=1
             )
             # Apply random LPF
             output = torchsig_convolve(flattened, taps, gpu=self.use_gpu)[:-num_taps]


### PR DESCRIPTION
* bandwidth of LPF for OFDM modulator is now randomized for 'rand_lpf'
* Filter lengths within OFDM modulator for firwin() in synthetic.py now estimated using function for 'rand_lpf' and 'lpf' sidelobe suppression methods

Resolves #97 

