### PR TITLE
Fixing syntax error in generate_sig53.py: os.root is invalid, but os.path is valid

### DIFF
--- a/scripts/generate_sig53.py
+++ b/scripts/generate_sig53.py
@@ -40,7 +40,7 @@ def generate(path: str, configs: List[conf.Sig53Config]):
     help="Generate impaired dataset. Ignored if --all=True (default)",
 )
 def main(root: str, all: bool, impaired: bool):
-    if not os.root.isdir(root):
+    if not os.path.isdir(root):
         os.mkdir(root)
 
     configs = [


### PR DESCRIPTION
generate_sig53.py has call os.root.isdir() which fails, however os.path.isdir() is valid. Details described in #145 