### PR TITLE
Fix RTD

### DIFF
--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -19,7 +19,7 @@ All the datasets have almost similar API. They all have a common argument:
 ``transform`` to transform the input data.
 
 
-.. currentmodule:: torchsig.datasets
+.. currentmodule:: torchsig.datasets.sig53
 
 
 Sig53
@@ -28,11 +28,15 @@ Sig53
 .. autoclass:: Sig53
 
 
+.. currentmodule:: torchsig.datasets.wideband_sig53
+
 WidebandSig53
 ~~~~~~~~~~~~~~
 
 .. autoclass:: WidebandSig53
 
+
+.. currentmodule:: torchsig.datasets.modulations
 
 ModulationsDataset
 ~~~~~~~~~~~~~~~~~~~~
@@ -40,11 +44,15 @@ ModulationsDataset
 .. autoclass:: ModulationsDataset
 
 
+.. currentmodule:: torchsig.datasets.wideband
+
 WidebandModulationsDataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: WidebandModulationsDataset
 
+
+.. currentmodule:: torchsig.datasets.synthetic
 
 DigitalModulationDataset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,6 +90,8 @@ FMDataset
 .. autoclass:: FMDataset
 
 
+.. currentmodule:: torchsig.datasets.wideband
+
 WidebandDataset
 ~~~~~~~~~~~~~~~~~~
 
@@ -94,11 +104,16 @@ SyntheticBurstSourceDataset
 .. autoclass:: SyntheticBurstSourceDataset
 
 
+.. currentmodule:: torchsig.datasets.file_datasets
+
+
 FileBurstSourceDataset
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: FileBurstSourceDataset
 
+
+.. currentmodule:: torchsig.datasets.radioml
 
 RadioML2016
 ~~~~~~~~~~~~~~

--- a/docs/transforms.rst
+++ b/docs/transforms.rst
@@ -11,9 +11,9 @@ This is useful if you have to build a more complex transformation pipeline
 .. contents:: Transforms
     :local:
 
-General Transforms
-------------------
-.. currentmodule:: torchsig.transforms
+Transforms
+----------
+.. currentmodule:: torchsig.transforms.transforms
 
 Transform
 ^^^^^^^^^
@@ -23,9 +23,9 @@ Compose
 ^^^^^^^^^
 .. autoclass:: Compose
 
-NoTransform
-^^^^^^^^^^^^^
-.. autoclass:: NoTransform
+Identity
+^^^^^^^^^
+.. autoclass:: Identity
 
 Lambda
 ^^^^^^^^^
@@ -50,48 +50,6 @@ Concatenate
 TargetConcatenate
 ^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: TargetConcatenate
-
-RandAugment
-^^^^^^^^^^^^^
-.. autoclass:: RandAugment
-
-
-Deep Learning Techniques
-------------------------
-.. currentmodule:: torchsig.transforms.deep_learning_techniques.dlt
-
-DatasetBasebandMixUp
-^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: DatasetBasebandMixUp
-
-DatasetBasebandCutMix
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: DatasetBasebandCutMix
-
-CutOut
-^^^^^^^^^
-.. autoclass:: CutOut
-
-PatchShuffle
-^^^^^^^^^^^^^
-.. autoclass:: PatchShuffle
-
-DatasetWidebandMixUp
-^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: DatasetWidebandMixUp
-
-DatasetWidebandCutMix
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: DatasetWidebandCutMix
-
-SpectrogramRandomResizeCrop
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: SpectrogramRandomResizeCrop
-
-
-Expert Feature Transforms
--------------------------
-.. currentmodule:: torchsig.transforms.expert_feature.eft
 
 InterleaveComplex
 ^^^^^^^^^^^^^^^^^
@@ -137,23 +95,50 @@ ReshapeTransform
 ^^^^^^^^^^^^^^^^^
 .. autoclass:: ReshapeTransform
 
-
-Signal Processing Transforms
-----------------------------
-.. currentmodule:: torchsig.transforms.signal_processing.sp
+RandAugment
+^^^^^^^^^^^^^
+.. autoclass:: RandAugment
 
 Normalize
 ^^^^^^^^^
 .. autoclass:: Normalize
 
+
+Augmentations
+-------------
+.. currentmodule:: torchsig.transforms.transforms
+
+DatasetBasebandMixUp
+^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DatasetBasebandMixUp
+
+DatasetBasebandCutMix
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DatasetBasebandCutMix
+
+CutOut
+^^^^^^^^^
+.. autoclass:: CutOut
+
+PatchShuffle
+^^^^^^^^^^^^^
+.. autoclass:: PatchShuffle
+
+DatasetWidebandMixUp
+^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DatasetWidebandMixUp
+
+DatasetWidebandCutMix
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DatasetWidebandCutMix
+
+SpectrogramRandomResizeCrop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: SpectrogramRandomResizeCrop
+
 RandomResample
 ^^^^^^^^^^^^^^^^^
 .. autoclass:: RandomResample
-
-
-System Impairment Transforms
------------------------------
-.. currentmodule:: torchsig.transforms.system_impairment.si
 
 RandomTimeShift
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -231,11 +216,6 @@ RandomConvolve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: RandomConvolve 
 
-
-Wireless Channel Transforms
-----------------------------
-.. currentmodule:: torchsig.transforms.wireless_channel.wce
-
 TargetSNR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: TargetSNR
@@ -260,15 +240,6 @@ RandomPhaseShift
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: RandomPhaseShift
 
-
-Spectrogram Transforms
-----------------------------
-.. currentmodule:: torchsig.transforms.spectrogram_transforms.spec
-
-SpectrogramResize
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: SpectrogramResize
-
 SpectrogramDropSamples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: SpectrogramDropSamples
@@ -288,3 +259,113 @@ SpectrogramMosaicCrop
 SpectrogramMosaicDownsample
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: SpectrogramMosaicDownsample
+
+
+Target Transforms
+-----------------
+.. currentmodule:: torchsig.transforms.target_transforms
+
+DescToClassName
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToClassName
+
+DescToClassNameSNR
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToClassNameSNR
+
+DescToClassIndex
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToClassIndex
+
+DescToClassIndexSNR
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToClassIndexSNR
+
+DescToMask
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToMask
+
+DescToMaskSignal
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToMaskSignal
+
+DescToMaskFamily
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToMaskFamily
+
+DescToMaskClass
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToMaskClass
+
+DescToSemanticClass
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToSemanticClass
+
+DescToBBox
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToBBox
+
+DescToAnchorBoxes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToAnchorBoxes
+
+DescPassThrough
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescPassThrough
+
+DescToBinary
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToBinary
+
+DescToCustom
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToCustom
+
+DescToClassEncoding
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToClassEncoding
+
+DescToWeightedMixUp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToWeightedMixUp
+
+DescToWeightedCutMix
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToWeightedCutMix
+
+DescToBBoxDict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToBBoxDict
+
+DescToBBoxSignalDict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToBBoxSignalDict
+
+DescToBBoxFamilyDict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToBBoxFamilyDict
+
+DescToInstMaskDict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToInstMaskDict
+
+DescToSignalInstMaskDict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToSignalInstMaskDict
+
+DescToSignalFamilyInstMaskDict
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToSignalFamilyInstMaskDict
+
+DescToListTuple
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: DescToListTuple
+
+ListTupleToDesc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: ListTupleToDesc
+
+LabelSmoothing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: LabelSmoothing
+


### PR DESCRIPTION
## Summary

Previous import changes and code restructuring broke the RTD module references for datasets and transforms. This PR updates the rst files to account for these changes. Inspired by issue #150 .

## Test Plan

Local verification with:

```
cd docs
make html
```

Then manually opened generated `index.html` file and all looks functional.
