### PR TITLE
Link torchsig.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<p align="center">
+<a align="center" href="http://torchsig.com">
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset="docs/torchsig_logo_white_dodgerblue.png">
         <img src="docs/logo.png" width="500">
     </picture>
-</p>
+</a>
 
 -----
 ![build](https://github.com/torchDSP/torchsig/actions/workflows/pip_build.yml/badge.svg?branch=37-automate-install-tests)
 
 
-TorchSig is an open-source signal processing machine learning toolkit based on the PyTorch data handling pipeline. The user-friendly toolkit simplifies common digital signal processing operations, augmentations, and transformations when dealing with both real and complex-valued signals. TorchSig streamlines the integration process of these signals processing tools building on PyTorch, enabling faster and easier development and research for machine learning techniques applied to signals data, particularly within (but not limited to) the radio frequency domain. An example dataset, Sig53, based on many unique communication signal modulations is included to accelerate the field of modulation classification. Additionally, an example wideband dataset, WidebandSig53, is also included that extends Sig53 with larger data example sizes containing multiple signals enabling accelerated research in the fields of wideband signal detection and recognition.
+[TorchSig](https://torchsig.com) is an open-source signal processing machine learning toolkit based on the PyTorch data handling pipeline. The user-friendly toolkit simplifies common digital signal processing operations, augmentations, and transformations when dealing with both real and complex-valued signals. TorchSig streamlines the integration process of these signals processing tools building on PyTorch, enabling faster and easier development and research for machine learning techniques applied to signals data, particularly within (but not limited to) the radio frequency domain. An example dataset, Sig53, based on many unique communication signal modulations is included to accelerate the field of modulation classification. Additionally, an example wideband dataset, WidebandSig53, is also included that extends Sig53 with larger data example sizes containing multiple signals enabling accelerated research in the fields of wideband signal detection and recognition.
 
 *TorchSig is currently in beta*
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a align="center" href="http://torchsig.com">
+<a align="center" href="https://torchsig.com">
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset="docs/torchsig_logo_white_dodgerblue.png">
         <img src="docs/logo.png" width="500">


### PR DESCRIPTION
## Summary

Make the logo in the README and the first "TorchSig" word in the README hyperlinks to [torchsig.com](https://torchsig.com). Inspired by #150 .

## Test Plan

Locally tested and verified on [forked branch's page](https://github.com/lboegner/torchsig/blob/lboegner/readme-link-website/README.md).