### PR TITLE
Fixing low_pass() transition_bandwidth parameter

### DIFF
--- a/torchsig/utils/dsp.py
+++ b/torchsig/utils/dsp.py
@@ -14,7 +14,6 @@ def low_pass(cutoff: float, transition_bandwidth: float) -> np.ndarray:
         transition_bandwidth (float): width of the transition region
 
     """
-    transition_bandwidth = (0.5 - cutoff) / 4
     num_taps = estimate_filter_length(transition_bandwidth)
     return sp.firwin(
         num_taps,


### PR DESCRIPTION
previously low_pass() discarded the transition_bandwidth parameter and instead recalculated internally, however low_pass() now accepts the transition_bandwidth parameter