### PR TITLE
Changed SigMFInterpreter class_target to "core:label"

### DIFF
--- a/torchsig/datasets/file_datasets.py
+++ b/torchsig/datasets/file_datasets.py
@@ -390,7 +390,7 @@ class SigMFInterpreter(TargetInterpreter):
         class_list: List[str],
         num_iq_samples: int = int(512 * 512),
         capture_duration_samples: int = int(512 * 512),
-        class_target: str = "core:description",
+        class_target: str = "core:label",
         **kwargs,
     ):
         self.target_file = target_file


### PR DESCRIPTION
According to the latest SigMF specification (https://github.com/sigmf/SigMF/blob/sigmf-v1.x/sigmf-spec.md#annotations-array) the default class_target should be "core:label". 