### PR TITLE
Use pytorch/cuda image instead of nvidia latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:24.06-py3
+FROM pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 keywords = ["signal processing", "machine learning"]
 dependencies = [
-    "torch==2.3.0",
+    "torch==2.3.1",
     "torchvision",
     "tqdm",
     "opencv-python==4.8.0.74",


### PR DESCRIPTION
12GB smaller and means pytorch 2.3 doesn't need to be reinstalled.