### PR TITLE
Make generated `WidebandModulationsDataset` samples independent of call order

### DIFF
--- a/torchsig/datasets/synthetic.py
+++ b/torchsig/datasets/synthetic.py
@@ -513,7 +513,7 @@ class OFDMDataset(SyntheticDataset):
                     sidelobe_suppression_method,
                     dc_subcarrier,
                     time_varying_realism,
-                ) = combinations[self.random_generator.randint(len(combinations))]
+                ) = combinations[self.random_generator.integers(len(combinations))]
                 meta = ModulatedRFMetadata(
                     sample_rate=0.0,
                     num_samples=self.num_iq_samples,

--- a/torchsig/datasets/synthetic.py
+++ b/torchsig/datasets/synthetic.py
@@ -513,7 +513,7 @@ class OFDMDataset(SyntheticDataset):
                     sidelobe_suppression_method,
                     dc_subcarrier,
                     time_varying_realism,
-                ) = combinations[np.random.randint(len(combinations))]
+                ) = combinations[self.random_generator.randint(len(combinations))]
                 meta = ModulatedRFMetadata(
                     sample_rate=0.0,
                     num_samples=self.num_iq_samples,

--- a/torchsig/datasets/wideband.py
+++ b/torchsig/datasets/wideband.py
@@ -900,6 +900,8 @@ class WidebandModulationsDataset(SignalDataset):
         if not self.update_rng:
             self.random_generator = np.random.default_rng(os.getpid())
             self.update_rng = True
+        original_state = np.random.get_state()
+        np.random.seed(seed)
         self.random_generator, self.transform, self.num_signals, self.snrs = (
             self._initialize_random_parameters(seed)
         )
@@ -1093,6 +1095,7 @@ class WidebandModulationsDataset(SignalDataset):
         if self.target_transform:
             target = self.target_transform(signal["metadata"])
 
+        np.random.set_state(original_state)
         return signal["data"]["samples"], target
 
     def __len__(self) -> int:

--- a/torchsig/datasets/wideband.py
+++ b/torchsig/datasets/wideband.py
@@ -192,7 +192,8 @@ class ModulatedSignalBurst(SignalBurst):
                 dc_subcarrier=("on", "off"),
                 time_varying_realism=("on", "off"),
                 center_freq=self.meta["center_freq"],
-                bandwidth=self.meta["bandwidth"]
+                bandwidth=self.meta["bandwidth"],
+                seed=self.random_generator.integers(123456789),
             )
         elif self.meta["class_name"] in torchsig_signals.fsk_signals: # FSK, GFSK, MSK, GMSK
             modulated_burst = FSKDataset(

--- a/torchsig/datasets/wideband.py
+++ b/torchsig/datasets/wideband.py
@@ -187,7 +187,7 @@ class ModulatedSignalBurst(SignalBurst):
                 num_subcarriers=tuple(num_subcarriers),  # possible number of subcarriers
                 num_iq_samples=num_iq_samples,
                 num_samples_per_class=1,
-                random_data=True,
+                random_data=False,
                 sidelobe_suppression_methods=sidelobe_suppression_methods,
                 dc_subcarrier=("on", "off"),
                 time_varying_realism=("on", "off"),
@@ -200,7 +200,7 @@ class ModulatedSignalBurst(SignalBurst):
                 num_iq_samples=num_iq_samples,
                 num_samples_per_class=1,
                 iq_samples_per_symbol=approx_samp_per_sym,
-                random_data=True,
+                random_data=False,
                 random_pulse_shaping=True,
                 center_freq=self.meta["center_freq"],
                 bandwidth=self.meta["bandwidth"]
@@ -211,7 +211,7 @@ class ModulatedSignalBurst(SignalBurst):
                 num_iq_samples=num_iq_samples,
                 num_samples_per_class=1,
                 iq_samples_per_symbol=approx_samp_per_sym,
-                random_data=True,
+                random_data=False,
                 random_pulse_shaping=False, #True, TODO fix pulse shaping code.
                 center_freq=self.meta["center_freq"],
             )

--- a/torchsig/datasets/wideband.py
+++ b/torchsig/datasets/wideband.py
@@ -744,7 +744,10 @@ class WidebandModulationsDataset(SignalDataset):
                 transforms=[
                     RandomApply(
                         RandomTimeShift(
-                            shift=(-int(num_iq_samples / 2), int(num_iq_samples / 2)),
+                            shift=(
+                                -int(self.num_iq_samples / 2),
+                                int(self.num_iq_samples / 2),
+                            ),
                             seed=seed,
                         ),
                         0.25,
@@ -756,7 +759,7 @@ class WidebandModulationsDataset(SignalDataset):
                     RandomApply(
                         RandomResample(
                             rate_ratio=(0.8, 1.2),
-                            num_iq_samples=num_iq_samples,
+                            num_iq_samples=self.num_iq_samples,
                             seed=seed,
                         ),
                         0.25,

--- a/torchsig/transforms/transforms.py
+++ b/torchsig/transforms/transforms.py
@@ -547,8 +547,9 @@ class RandomResample(SignalTransform):
         num_iq_samples: int = 4096,
         keep_samples: bool = False,
         min_time: float = .05,
+        **kwargs,
     ) -> None:
-        super(RandomResample, self).__init__()
+        super(RandomResample, self).__init__(**kwargs)
         self.rate_ratio: Callable = to_distribution(rate_ratio, self.random_generator)
         self.num_iq_samples = num_iq_samples
         self.keep_samples = keep_samples
@@ -2253,8 +2254,9 @@ class IQImbalance(SignalTransform):
             np.pi * 1.0 / 180.0,
         ),
         iq_dc_offset_db: NumericParameter = (-0.1, 0.1),
+        **kwargs
     ) -> None:
-        super(IQImbalance, self).__init__()
+        super(IQImbalance, self).__init__(**kwargs)
         self.amp_imbalance = to_distribution(
             iq_amplitude_imbalance_db, self.random_generator
         )
@@ -2319,8 +2321,9 @@ class RollOff(SignalTransform):
         low_cut_apply: float = 0.5,
         upper_cut_apply: float = 0.5,
         order: NumericParameter = (6, 20),
+        **kwargs
     ) -> None:
-        super(RollOff, self).__init__()
+        super(RollOff, self).__init__(**kwargs)
         self.low_freq = to_distribution(low_freq, self.random_generator)
         self.upper_freq = to_distribution(upper_freq, self.random_generator)
         self.low_cut_apply = low_cut_apply
@@ -2492,8 +2495,9 @@ class RandomDropSamples(SignalTransform):
         drop_rate: NumericParameter = (0.01, 0.05),
         size: NumericParameter = (1, 10),
         fill: List[str] = (["ffill", "bfill", "mean", "zero"]),
+        **kwargs,
     ) -> None:
-        super(RandomDropSamples, self).__init__()
+        super(RandomDropSamples, self).__init__(**kwargs)
         self.drop_rate = to_distribution(drop_rate, self.random_generator)
         self.size = to_distribution(size, self.random_generator)
         self.fill = to_distribution(fill, self.random_generator)

--- a/torchsig/transforms/transforms.py
+++ b/torchsig/transforms/transforms.py
@@ -100,12 +100,8 @@ class Transform:
     """
 
     def __init__(self, seed: Optional[int] = None) -> None:
-        if seed is not None:
-            warnings.warn(
-                "Seeding transforms is deprecated and does nothing", DeprecationWarning
-            )
         self.string = self.__class__.__name__ + "()"
-        self.random_generator = np.random.default_rng()
+        self.random_generator = np.random.default_rng(seed)
 
     def __call__(self, data: Any) -> Any:
         raise NotImplementedError


### PR DESCRIPTION
Please see the linked issue (#250) for details.