### PR TITLE
fix ReadTheDocs pipeline

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,4 +28,6 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
+    - method: pip
+      path: .
     - requirements: docs/docs-requirements.txt


### PR DESCRIPTION
Updated `.readthedocs.yaml` so our [ReadTheDocs](https://torchsig.readthedocs.io/en/latest/index.html) is updated with our documentation.