### PR TITLE
fix: include YAML config files in package installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dynamic = ["version"]
 [tool.setuptools.dynamic]
 version = {attr = "torchsig.__version__"}
 
+[tool.setuptools.package-data]
+"torchsig.datasets.default_configs" = ["*.yaml"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
This PR fixes issue #296 where the generate_official_datasets.py script fails with a FileNotFoundError when attempting to access YAML configuration files.

The error occurs because YAML configuration files in the default_configs directory are not included in the installed package.

Changes:
Added an entry to pyproject.toml to include *.yaml files from the default_configs directory in the package installation.