### PR TITLE
fixes #453

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
+# Replace opencv-python with opencv-python-headless
+RUN sed -i 's/opencv-python/opencv-python-headless/g' pyproject.toml
+
 # Install Python dependencies
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install build setuptools

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -18,6 +18,9 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /workspace
 
+# Copy torchsig
+COPY ../. .
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -33,12 +36,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
+# Replace opencv-python with opencv-python-headless
+RUN sed -i 's/opencv-python/opencv-python-headless/g' pyproject.toml
+
 # Install Python dependencies
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install build setuptools
-
-# Copy torchsig
-COPY ../. .
 
 # Install torchsig
 RUN pip install --no-cache-dir .

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,10 @@
 # TorchSig: Docker
 
+Run TorchSig using Docker. We have two Dockerfiles, one CPU only and the other GPU capable.
+
 ## Base TorchSig Image (`Dockerfile`)
 - CPU only
-- 7 GB
+- Image size: ~7 GB
 ```bash
 docker build -t torchsig -f docker/Dockerfile .
 docker run -it torchsig
@@ -12,7 +14,7 @@ docker run -it torchsig
 - Ubuntu 22.04
 - NVIDIA CUDA 11.8.0
 - Python 3.10
-- 7 GB
+- Image size: ~7 GB
 ```bash
 docker build -t torchsig-gpu -f docker/Dockerfile.gpu .
 docker run -it torchsig-gpu


### PR DESCRIPTION
Added one-liner in both Dockerfiles to replace `opencv-python` with `opencv-python-headless`