### PR TITLE
Fix passband_ripple() rejection-sampling budget crash

### DIFF
--- a/tests/transforms/test_functional.py
+++ b/tests/transforms/test_functional.py
@@ -1013,6 +1013,30 @@ def test_passband_ripple(params: dict, expected: bool, is_error: bool) -> None:
         assert (data.dtype == TorchSigComplexDataType) == expected
 
 
+def test_passband_ripple_worst_case_corner_does_not_crash() -> None:
+    """Regression test: passband_ripple()'s internal rejection-sampling loop must not
+    exhaust its retry budget and raise at num_taps=3/max_ripple_db=1.0/
+    coefficient_decay_rate=1.0 - the tightest corner of PassbandRipple's own default
+    distributions ((1, 2) and (1, 5) respectively combined with num_taps in [2, 3]).
+
+    At that corner the per-draw acceptance probability is only ~0.25% (empirically
+    measured), so with the previous 1000-try budget there was roughly an 8% chance of
+    exhausting it and raising ValueError on any single call - which, applied across a
+    real dataset generation run (many thousands of PassbandRipple invocations), reliably
+    crashed the whole run. Running this corner repeatedly across many independent seeds
+    gives strong statistical coverage that the retry budget is now large enough.
+    """
+    num_taps = 3
+    max_ripple_db = 1.0
+    coefficient_decay_rate = 1.0
+
+    for seed in range(200):
+        rng = np.random.default_rng(seed)
+        data = dsp.noise_generator(num_samples=128, power=1.0, color="white", continuous=False, rng=rng)
+        # must not raise
+        passband_ripple(data=data, num_taps=num_taps, max_ripple_db=max_ripple_db, coefficient_decay_rate=coefficient_decay_rate, rng=rng)
+
+
 @pytest.mark.parametrize(
     "data, params, expected, is_error", [(0, {"patch_size": 3, "patches_to_shuffle": [2, 7]}, TypeError, True), (TEST_DATA.copy(), {"patch_size": 3, "patches_to_shuffle": [2, 7]}, True, False)]
 )

--- a/torchsig/transforms/functional.py
+++ b/torchsig/transforms/functional.py
@@ -1063,11 +1063,21 @@ def passband_ripple(
     rng = rng or np.random.default_rng()
     # counter avoids infinite loop
     counter = 0
-    max_counter = 1000
+    # Rejection-sampling budget. For max_ripple_db/coefficient_decay_rate values
+    # near the tight corner of PassbandRipple's default distributions ((1, 2) and
+    # (1, 5) respectively) combined with num_taps=3, the per-draw acceptance
+    # probability can be as low as ~0.25% (measured empirically) - giving roughly
+    # an 8% chance of exhausting a 1000-iteration budget on any single call. Over
+    # a large dataset generation run (many thousands of PassbandRipple
+    # invocations), that reliably crashes the whole run. 100,000 iterations
+    # reduces the failure probability to effectively zero (< 1e-100 in the worst
+    # empirically-measured corner) while adding negligible runtime - each
+    # iteration is just a cheap 1024-point FFT.
+    max_counter = 100_000
     # initialize estimate such that it always enters loop
     estimate_ripple_db = max_ripple_db + 1
 
-    while estimate_ripple_db > max_ripple_db and counter < 1000:
+    while estimate_ripple_db > max_ripple_db and counter < max_counter:
         # designs the weights: complex gaussian with exponential decay
         gaussian = rng.normal(0, 1, num_taps) + 1j * rng.normal(0, 1, num_taps)
         decay = np.exp(-coefficient_decay_rate * np.arange(0, num_taps))


### PR DESCRIPTION
Fixes #482.

## Problem

`passband_ripple()` (used by the `PassbandRipple` impairment, which fires on ~75% of signals at `Impairments(level=2)`) does rejection sampling: it draws random filter taps until one meets a target ripple spec, giving up after a hardcoded 1000 tries and raising `ValueError`.

For `max_ripple_db`/`coefficient_decay_rate` values near the tight corner of `PassbandRipple`'s **own default distributions** (`max_ripple_db: (1, 2)`, `coefficient_decay_rate: (1, 5)`) combined with `num_taps=3` (from `num_taps: [2, 3]`), the per-draw acceptance probability is only ~0.25% (measured empirically) - about an 8% chance of exhausting the 1000-try budget on a single call. Across a real dataset generation run (many thousands of `PassbandRipple` invocations via `DatasetCreator`), this reliably crashes the whole run.

Reproduced deterministically, twice in a row, generating an 18,000-sample impaired-level dataset with a fixed seed: both runs crashed in the same `DataLoader` worker at the same ~28%-through progress point.

See #482 for the full writeup (root-cause derivation, acceptance-probability math).

## Fix

Two changes in `passband_ripple()`:

1. Raise the rejection-sampling budget from 1000 to 100,000 tries. This reduces the failure probability to well under 1e-100 at the worst empirically-measured corner, while adding negligible runtime (each try is a cheap 1024-point FFT).
2. Fix the loop's exit condition, which used a hardcoded `1000` literal (`counter < 1000`) instead of the `max_counter` variable it's paired with in the post-loop check (`counter >= max_counter`). Today both happen to be 1000, so this had no visible effect - but bumping just `max_counter` without also fixing this would have silently disabled the `ValueError` safety net instead of extending the budget (the loop would still bail at 1000 tries, then proceed to apply the last, out-of-spec `weights` without ever raising).

## Testing

- Added `test_passband_ripple_worst_case_corner_does_not_crash` (`tests/transforms/test_functional.py`): runs the worst-case corner (`num_taps=3`, `max_ripple_db=1.0`, `coefficient_decay_rate=1.0`) across 200 independent seeds and asserts no `ValueError`. Passes locally after the fix (existing `test_passband_ripple`/`test_PassbandRipple` tests also still pass).
- Manually verified: 0/200 failures at the exact worst-case corner via a standalone repro (down from the expected ~8% pre-fix).
- Regenerated the real 18,000-sample impaired-level dataset that crashed twice pre-fix; it now completes cleanly end-to-end.
